### PR TITLE
Новый метод, получение информации о заказе.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -322,7 +322,7 @@ class Client implements LoggerAwareInterface
     /**
      * Полная информация о заказе по ID заказа в магазине
      *
-     * @param $order_id
+     * @param $order_id - ID заказа магазина
      * @return array
      * @throws BoxBerryException
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -307,24 +307,28 @@ class Client implements LoggerAwareInterface
     }
 
     /**
-     * Полная информация по заказу
+     * Полная информация о заказе по трек номеру
      *
      * @param $track_id - трекномер BB
-     * @param null $order_id - ID заказа магазина
      * @return array
      * @throws BoxBerryException
      *
      */
-    public function getOrderFullInfo($track_id, $order_id = null)
+    public function getOrderFullInfoByTrack($track_id)
     {
-        $order_id = empty($track_id) ? $order_id : null;
-        $track_id = empty($order_id) ? $track_id : null;
-        if (!empty($track_id) && !empty($order_id)) {
-            $order_id = null;
-        }
+        return $this->callApi('POST', 'ParcelInfo', ['track' => $track_id]);
+    }
 
-        $params = ['track' => $track_id, 'order_id' => $order_id];
-        return $this->callApi('POST', 'ParcelInfo', $params);
+    /**
+     * Полная информация о заказе по ID заказа в магазине
+     *
+     * @param $order_id
+     * @return array
+     * @throws BoxBerryException
+     */
+    public function getOrderFullInfoByOrderId($order_id)
+    {
+        return $this->callApi('POST', 'ParcelInfo', ['order_id' => $order_id]);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -295,6 +295,8 @@ class Client implements LoggerAwareInterface
     }
 
     /**
+     * Этикетка по заказу
+     *
      * @param string $order_id - ID заказа магазина или трекномер BB
      * @return array
      * @throws BoxBerryException
@@ -302,6 +304,27 @@ class Client implements LoggerAwareInterface
     public function getOrderInfo($order_id)
     {
         return $this->callApi('GET', 'ParselCheck', ['ImId' => $order_id]);
+    }
+
+    /**
+     * Полная информация по заказу
+     *
+     * @param $track_id - трекномер BB
+     * @param null $order_id - ID заказа магазина
+     * @return array
+     * @throws BoxBerryException
+     *
+     */
+    public function getOrderFullInfo($track_id, $order_id = null)
+    {
+        $order_id = empty($track_id) ? $order_id : null;
+        $track_id = empty($order_id) ? $track_id : null;
+        if (!empty($track_id) && !empty($order_id)) {
+            $order_id = null;
+        }
+
+        $params = ['track' => $track_id, 'order_id' => $order_id];
+        return $this->callApi('POST', 'ParcelInfo', $params);
     }
 
     /**


### PR DESCRIPTION
Текущий метод getOrderInfo не отдает информации о заказе, по этому методу получаем этикетку по заказу. Вот инфо с оф источника https://help.boxberry.ru/pages/viewpage.action?pageId=1704636  Добавил новый метод на получение полной информации о заказе. В методе 2 параметра трек номер и номер заказа магазина. Одновременно можно отправить только 1 параметр для получения информации о заказе, если отправить сразу 2 параметра не null то ББ выдаст ошибку. Поэтому добавил проверку на параметры. Если будет передан только 1 параметр это трек номер и инфу о заказе получаем на основании трек номера. Если переданы оба заполненных параметра то приоритет отдаем трек номеру.