### PR TITLE
Добавлены новые методы для получения файлов

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ $bbClient->setToken('main', 'bb_api_token');
 [Список заказов не добавленных в акт](#getOrdersNotAct)  
 [Создание акта передачи посылок](#createOrdersTransferAct)  
 [Список созданных актов передачи посылок](#getActsList)  
+[Получить файл "Акта приема передачи посылки (АПП)" по номеру АПП](#getParcelFileActToId)  
+[Получить файл акта ТМЦ (если подключена услуга в ЛК) по номеру АПП](#getParcelFileActTMCToId)  
+[Получить печатную форму этикеток по номеру АПП](#getParcelFileBarcodesToId)  
   
 
 <a name="links"><h1>Changelog</h1></a>
@@ -1458,6 +1461,102 @@ try {
      
      )
      */
+}
+catch (\WildTuna\BoxberrySdk\Exception\BoxBerryException $e) {
+    // Обработка ошибки вызова API BB
+    // $e->getMessage(); текст ошибки 
+    // $e->getCode(); http код ответа сервиса BB
+    // $e->getRawResponse(); // ответ сервера BB как есть (http request body)
+}
+
+catch (\Exception $e) {
+    // Обработка исключения
+}
+```
+
+<a name="getParcelFileActToId"><h1>Получить файл "Акта приема передачи посылки (АПП)" по номеру АПП</h1></a>  
+Позволяет получить файл "Акта приема передачи посылки (АПП)" по номеру АПП
+
+**Входные параметры:**
+- *$parcelId* - номер АПП
+
+**Выходные параметры:**  
+Ассоциативный массив данных
+
+**Примеры вызова:**
+```php
+<?php
+
+try {
+    $bbClient = new \WildTuna\BoxberrySdk\Client();
+    $bbClient->setToken('main', 'bb_api_token'); // Заносим токен BB и присваиваем ему ключ main
+    $bbClient->setCurrentToken('main');
+    
+    $result = $bbClient->getParcelFileActToId('12942207');
+}
+catch (\WildTuna\BoxberrySdk\Exception\BoxBerryException $e) {
+    // Обработка ошибки вызова API BB
+    // $e->getMessage(); текст ошибки 
+    // $e->getCode(); http код ответа сервиса BB
+    // $e->getRawResponse(); // ответ сервера BB как есть (http request body)
+}
+
+catch (\Exception $e) {
+    // Обработка исключения
+}
+```
+
+<a name="getParcelFileActTMCToId"><h1>Получить файл акта ТМЦ (если подключена услуга в ЛК) по номеру АПП</h1></a>  
+Позволяет получить файл акта ТМЦ (если подключена услуга в ЛК) по номеру АПП
+
+**Входные параметры:**
+- *$parcelId* - номер АПП
+
+**Выходные параметры:**  
+Ассоциативный массив данных
+
+**Примеры вызова:**
+```php
+<?php
+
+try {
+    $bbClient = new \WildTuna\BoxberrySdk\Client();
+    $bbClient->setToken('main', 'bb_api_token'); // Заносим токен BB и присваиваем ему ключ main
+    $bbClient->setCurrentToken('main');
+    
+    $result = $bbClient->getParcelFileActTMCToId('12942207');
+}
+catch (\WildTuna\BoxberrySdk\Exception\BoxBerryException $e) {
+    // Обработка ошибки вызова API BB
+    // $e->getMessage(); текст ошибки 
+    // $e->getCode(); http код ответа сервиса BB
+    // $e->getRawResponse(); // ответ сервера BB как есть (http request body)
+}
+
+catch (\Exception $e) {
+    // Обработка исключения
+}
+```
+
+<a name="getParcelFileBarcodesToId"><h1>Получить печатную форму этикеток по номеру АПП</h1></a>  
+Позволяет получить печатную форму этикеток по номеру АПП
+
+**Входные параметры:**
+- *$parcelId* - номер АПП
+
+**Выходные параметры:**  
+Ассоциативный массив данных
+
+**Примеры вызова:**
+```php
+<?php
+
+try {
+    $bbClient = new \WildTuna\BoxberrySdk\Client();
+    $bbClient->setToken('main', 'bb_api_token'); // Заносим токен BB и присваиваем ему ключ main
+    $bbClient->setCurrentToken('main');
+    
+    $result = $bbClient->getParcelFileBarcodesToId('12942207');
 }
 catch (\WildTuna\BoxberrySdk\Exception\BoxBerryException $e) {
     // Обработка ошибки вызова API BB

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $bbClient->setToken('main', 'bb_api_token');
   
 
 <a name="links"><h1>Changelog</h1></a>
+- 0.8.5 - Добавлены методы для прямого получения печатных форм: акта, акта ТМЦ, этикеток по АПП. Доработкой занимался [Maxim Rodionov](https://github.com/maxbrown1);
 - 0.8.4 - Добавлен метод получения этикетки. Спасибо [Maxim Rodionov](https://github.com/maxbrown1) за доработку;    
 - 0.8.3 - Исправлен вызов методов поулчения информации о заказе. Спасибо [Maxim Rodionov](https://github.com/maxbrown1) за доработку;   
 - 0.8.1 - Добавлены новые методы API. Подробнее [тут](https://github.com/iamwildtuna/boxberry-sdk/releases/tag/0.8.1). Спасибо [Maxim Rodionov](https://github.com/maxbrown1) за доработку;   

--- a/src/Client.php
+++ b/src/Client.php
@@ -506,4 +506,51 @@ class Client implements LoggerAwareInterface
 
         return $this->callApi('GET', 'ParselSendStory', $params);
     }
+
+    /**
+     * @param string $typeFile - тип файла, принимает значения 'act' - Акт приема передачи посылки, 'barcodes' - печатная форма этикеток
+     * @param array $params - параметры
+     * @return mixed
+     */
+    private function parcelFiles($typeFile = '', $params = [])
+    {
+        $uri = 'https://api.boxberry.ru/parcel-files/' . $typeFile;
+        $this->httpClient = new \GuzzleHttp\Client(['base_uri' => $uri, 'timeout' => 300]);
+        $params['token'] = $this->getCurrentToken();
+
+        return $this->httpClient->get('', ['query' => $params]);
+    }
+
+    /**
+     * Позволяет получить файл "Акта приема передачи посылки (АПП)" по номеру АПП
+     *
+     * @param $parcelId - номер акта приема передачи посылки
+     * @return mixed
+     */
+    public function getParcelFileActToId($parcelId)
+    {
+        return $this->parcelFiles('act', ['upload_id' => $parcelId]);
+    }
+
+    /**
+     * Позволяет получить файл акта ТМЦ (если подключена услуга в ЛК) по номеру АПП
+     *
+     * @param $parcelId - номер акта приема передачи посылки
+     * @return mixed
+     */
+    public function getParcelFileActTMCToId($parcelId)
+    {
+        return $this->parcelFiles('act', ['upload_id' => $parcelId, 'type_act' => 'tmc']);
+    }
+
+    /**
+     * Позволяет получить печатную форму этикеток по номеру АПП
+     *
+     * @param $parcelId - номер акта приема передачи посылки
+     * @return mixed
+     */
+    public function getParcelFileBarcodesToId($parcelId)
+    {
+        return $this->parcelFiles('barcodes', ['upload_id' => $parcelId]);
+    }
 }


### PR DESCRIPTION
На данный момент у Боксберри нет прямых методов на получение файлов связанных с АПП. Боксберри только отдает ссылки на получение файлов. Чтобы была возможность получения файлов напрямую по номеру АПП были добавлены новые методы